### PR TITLE
[BioSerDe-13] Initial bed serde demonstration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-noodles = { version = "0.24", features = ["core", "bed"], git = "https://github.com/umccr/noodles.git", branch = "serde" }
-noodles-bed = { version = "0.3", git = "https://github.com/umccr/noodles.git", branch = "serde" }
+noodles = { version = "0.24", features = ["core", "bed"], git = "https://github.com/umccr/noodles.git", branch = "bed_serde" }
+noodles-bed = { version = "0.3", git = "https://github.com/umccr/noodles.git", branch = "bed_serde" }
 
 async-trait = { version = "0.1" }
 arrow = { version = "17" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{:?}", bed_records);
 
     let bed_record_serialization= bed::to_string(&bed_records)?;
-    println!("{:#?}", bed_record_serialization);
+    println!("{:?}", bed_record_serialization);
+
+    let test_1 = r#"{"chrom":"chr7","start":127471197,"end":127472363}"#;
+    let bed_record_deserialization_test_1: Record::<3> = bed::from_str(test_1).unwrap();
+    println!("{:?}", bed_record_deserialization_test_1);
+
+    // // Doesn't work yet
+    // // (Should it?)
+    // let test_2 = r#"[
+    //     {"chrom":"chr7","start":127471197,"end":127472363},
+    //     {"chrom":"chr7","start":127472364,"end":127473530},
+    //     {"chrom":"chr7","start":127473531,"end":127474697}
+    // ]"#;
+    // let bed_record_deserialization_test_2: Vec<Record::<3>> = bed::from_str(test_2).unwrap();
+    // println!("{:?}", bed_record_deserialization_test_2);
 
     // assert_eq!(reference, serialized);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,16 +2,24 @@
 
 use std::{fs::{File, self}, io::BufReader};
 
+use bed::Record;
 use noodles_bed as bed;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let src = "../data/bed/well_formed_sample.bed";
+    let src = "data/bed/well_formed_sample.bed";
 
     let mut reader = File::open(src).map(BufReader::new).map(bed::Reader::new)?;
     let reference = fs::read_to_string(src)?;
-    let serialized = bed::to_string(&reader)?;
 
-    assert_eq!(reference, serialized);
+    println!("{:?}", reference);
+
+    let bed_records: Vec<Record<3>> = bed::from_reader(&mut reader);
+    println!("{:?}", bed_records);
+
+    let bed_record_serialization= bed::to_string(&bed_records)?;
+    println!("{:#?}", bed_record_serialization);
+
+    // assert_eq!(reference, serialized);
 
     Ok(())
 }


### PR DESCRIPTION
resolves #13 

This PR demonstrates the changes on [this PR on ummcr/noodles](https://github.com/umccr/noodles/pull/1)

For your convenience, `cargo run` currently prints:

```
"chr7\t127471196\t127472363\nchr7\t127472363\t127473530\nchr7\t127473530\t127474697"

[Record { standard_fields: StandardFields { reference_sequence_name: "chr7", start_position: Position(127471197), end_position: Position(127472363), name: None, score: None, strand: None, thick_start: Position(127471197), thick_end: Position(127472363), color: None, blocks: [] }, optional_fields: OptionalFields([]) }, Record { standard_fields: StandardFields { reference_sequence_name: "chr7", start_position: Position(127472364), end_position: Position(127473530), name: None, score: None, strand: None, thick_start: Position(127472364), thick_end: Position(127473530), color: None, blocks: [] }, optional_fields: OptionalFields([]) }, Record { standard_fields: StandardFields { reference_sequence_name: "chr7", start_position: Position(127473531), end_position: Position(127474697), name: None, score: None, strand: None, thick_start: Position(127473531), thick_end: Position(127474697), color: None, blocks: [] }, optional_fields: OptionalFields([]) }]

"[{\"chrom\":\"chr7\",\"start\":127471197,\"end\":127472363},{\"chrom\":\"chr7\",\"start\":127472364,\"end\":127473530},{\"chrom\":\"chr7\",\"start\":127473531,\"end\":127474697}]"
```